### PR TITLE
Redirect all laravel requests to root component

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,6 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', function () {
+Route::get('/{any}', function () {
     return view('welcome');
-});
+})->where('any', '.*');


### PR DESCRIPTION
At this juncture, I redirected all Laravel route requests to return the `wecome.blade.php` view so that the vue router can take charge of the routing.