### PR TITLE
Hide login/register from authenticated users

### DIFF
--- a/resources/js/App.vue
+++ b/resources/js/App.vue
@@ -27,17 +27,17 @@
               >Contact</router-link
             >
           </li>
-          <li>
+          <li v-if="!loggedIn">
             <router-link @click="hideOverlay" :to="{ name: 'Register' }"
               >Register</router-link
             >
           </li>
-          <li>
+          <li v-if="!loggedIn">
             <router-link @click="hideOverlay" :to="{ name: 'Login' }"
               >Login</router-link
             >
           </li>
-          <li>
+          <li v-if="loggedIn">
             <router-link @click="hideOverlay" :to="{ name: 'Dashboard' }"
               >Dashboard</router-link
             >
@@ -66,7 +66,7 @@
     <main class="container">
       <!-- render components depending on the page visited -->
 
-      <router-view></router-view>
+      <router-view @update-sidebar="updateSidebar"></router-view>
     </main>
 
     <!-- Main footer -->
@@ -85,6 +85,7 @@ export default {
   data() {
     return {
       overlayVisibility: false,
+      loggedIn: false,
     };
   },
   methods: {
@@ -95,6 +96,18 @@ export default {
     hideOverlay() {
       this.overlayVisibility = false;
     },
+
+    updateSidebar() {
+      this.loggedIn = !this.loggedIn;
+    },
+  },
+
+  mounted() {
+    if (localStorage.getItem("authenticated")) {
+      this.loggedIn = true;
+    } else {
+      this.loggedIn = false;
+    }
   },
 };
 </script>

--- a/resources/js/pages/Login.vue
+++ b/resources/js/pages/Login.vue
@@ -30,6 +30,8 @@ export default {
         .post("/api/login", this.fields)
         .then(() => {
           this.$router.push({ name: "Dashboard" });
+          localStorage.setItem("authenticated", "true");
+          this.$emit("updateSidebar");
         })
         .catch((error) => {
           this.errors = error.response.data.errors;


### PR DESCRIPTION
At this juncture of development I implemented the following:
- Set authenticated in local storage to true when a user is logged in
- Emit updateSidebar event to the root component to update the sidebar
- Render the login, register, and dashboard links dynamically depending on the status of the authenticated key in the local storage.