### PR TITLE
Hide dashboard link from guests

### DIFF
--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -33,7 +33,11 @@ export default {
     logout() {
       axios
         .post("/api/logout")
-        .then((response) => this.$router.push({ name: "Home" }))
+        .then((response) => {
+          this.$router.push({ name: "Home" });
+          localStorage.removeItem("authenticated");
+          this.$emit("updateSidebar");
+        })
         .catch((error) => console.log(error));
     },
   },


### PR DESCRIPTION
At this juncture of development I implemented the following:
- Cleared the local storage when a user logs out.
- Emit an event to toggle `loggedIn` status to false when a user logs out. 