### PR TITLE
Display related posts dynamically

### DIFF
--- a/app/Http/Controllers/RelatedPostController.php
+++ b/app/Http/Controllers/RelatedPostController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\PostResource;
+use Illuminate\Http\Request;
+use App\Models\Post;
+
+class RelatedPostController extends Controller
+{
+    public function index(Post $post)
+    {
+        $category = $post->category;
+
+        $relatedPosts = $category->posts()->where('id', '!=', $post->id)->latest()->take(3)->get();
+        return PostResource::collection($relatedPosts);
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -8,4 +8,9 @@ use Illuminate\Database\Eloquent\Model;
 class Category extends Model
 {
     use HasFactory;
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -13,4 +13,9 @@ class Post extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function category()
+    {
+        return $this->belongsTo(Category::class);
+    }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -507,7 +507,7 @@ textarea {
     }
 }
 
-.router-link-active {
+.side-links .router-link-active {
     background-color: orangered;
     color: #fff;
     padding: 3px 15px;

--- a/resources/js/App.vue
+++ b/resources/js/App.vue
@@ -66,7 +66,10 @@
     <main class="container">
       <!-- render components depending on the page visited -->
 
-      <router-view @update-sidebar="updateSidebar"></router-view>
+      <router-view
+        @update-sidebar="updateSidebar"
+        :key="$route.path"
+      ></router-view>
     </main>
 
     <!-- Main footer -->

--- a/resources/js/pages/SingleBlog.vue
+++ b/resources/js/pages/SingleBlog.vue
@@ -20,24 +20,19 @@
   <section class="recommended">
     <p>Related</p>
     <div class="recommended-cards">
-      <a href="">
+      <router-link
+        v-for="relatedPost in relatedPosts"
+        :key="relatedPost.id"
+        :to="{
+          name: 'SingleBlog',
+          params: { slug: relatedPost.slug },
+        }"
+      >
         <div class="recommended-card">
-          <img src="/images/pic5.jpg" alt="" loading="lazy" />
-          <h4>12 Health Benefits Of Pomegranate Fruit</h4>
+          <img :src="`/${relatedPost.imagePath}`" alt="" loading="lazy" />
+          <h4>{{ relatedPost.title }}</h4>
         </div>
-      </a>
-      <a href="">
-        <div class="recommended-card">
-          <img src="/images/pushups.jpg" alt="" loading="lazy" />
-          <h4>The Truth About Pushups</h4>
-        </div>
-      </a>
-      <a href="">
-        <div class="recommended-card">
-          <img src="/images/smoothies.jpg" alt="" loading="lazy" />
-          <h4>Healthy Smoothies</h4>
-        </div>
-      </a>
+      </router-link>
     </div>
   </section>
 </template>
@@ -48,12 +43,20 @@ export default {
   data() {
     return {
       post: {},
+      relatedPosts: [],
     };
   },
   mounted() {
     axios
       .get("/api/posts/" + this.slug)
       .then((response) => (this.post = response.data.data))
+      .catch((error) => {
+        console.log(error);
+      });
+
+    axios
+      .get("/api/related-posts/" + this.slug)
+      .then((response) => (this.relatedPosts = response.data.data))
       .catch((error) => {
         console.log(error);
       });

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\PostController;
+use App\Http\Controllers\RelatedPostController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Http\Controllers\AuthenticatedSessionController;
@@ -46,3 +47,4 @@ Route::get('categories', [CategoryController::class, 'index']);
 Route::get('home-posts', [HomeController::class, 'index']);
 Route::get('posts/{post:slug}', [PostController::class, 'show']);
 Route::get('posts', [PostController::class, 'index']);
+Route::get('related-posts/{post:slug}', [RelatedPostController::class, 'index']);


### PR DESCRIPTION
At this juncture of development I implemented the following:
- Created an `api` to fetch the latest 3 related blog posts to a single blog post.
- Fetched all the related blog posts and displayed them at the bottom of a single blog post.